### PR TITLE
Avoid internal error when compiling traceback info for an unknown OSError

### DIFF
--- a/friendly_traceback/runtime_errors/os_error.py
+++ b/friendly_traceback/runtime_errors/os_error.py
@@ -12,7 +12,7 @@ def get_cause(_value, _frame, tb_data):
         or "requests.exception" in tb
     ):
         return handle_connection_error()
-    return no_information()
+    return {"cause": no_information()}
 
 
 def handle_connection_error():

--- a/tests/runtime/test_os_error.py
+++ b/tests/runtime/test_os_error.py
@@ -1,3 +1,4 @@
+import pytest
 import friendly_traceback
 
 
@@ -15,6 +16,16 @@ def test_Urllib_error():
         assert "An exception of type `URLError` is a subclass of `OSError`." in result
         assert "I suspect that you are trying to connect to a server" in result
     return result, message
+
+
+def test_no_information():
+    # simulate an unknown OSError
+    with pytest.raises(OSError) as exc_info:
+        raise OSError
+
+    ft_tb = friendly_traceback.core.FriendlyTraceback(exc_info.type, exc_info.value, exc_info.tb)
+    ft_tb.compile_info()
+    assert ft_tb.info["cause"] == friendly_traceback.ft_gettext.no_information()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The added test reproduces the error: when an unknown `OSError` is raised, `friendly` greets with a `TypeError: dict.update() argument after ** must be a mapping, not str`. The reason for this is the cause info being returned as a plain string, not dict.