### PR TITLE
Add type hints for `friendly_traceback.core`

### DIFF
--- a/friendly_traceback/core.py
+++ b/friendly_traceback/core.py
@@ -391,6 +391,8 @@ class FriendlyTraceback:
     * what() shows the information compiled by assign_generic()
     """
 
+    info: Info
+
     def __init__(self, etype: Type[_E], value: _E, tb: types.TracebackType) -> None:
         """The basic argument are those generated after a traceback
         and obtained via::
@@ -408,7 +410,7 @@ class FriendlyTraceback:
             print("Please report this issue.")
             raise SystemExit
         self.suppressed = ["       ... " + _("More lines not shown.") + " ..."]
-        self.info: Info = {"header": _("Python exception:")}
+        self.info = {"header": _("Python exception:")}
         self.message = self.assign_message()  # language independent
         self.assign_tracebacks()
 

--- a/friendly_traceback/core.py
+++ b/friendly_traceback/core.py
@@ -18,6 +18,7 @@ from itertools import dropwhile
 
 from . import debug_helper
 from . import info_generic
+from . import info_specific
 from . import info_variables
 
 from .base_formatters import Info
@@ -494,8 +495,6 @@ class FriendlyTraceback:
         if self.tb_data.filename == "<stdin>":  # pragma: no cover
             self.info["cause"] = cannot_analyze_stdin()
             return
-
-        from . import info_specific
 
         cause = info_specific.get_likely_cause(
             etype, value, self.tb_data.exception_frame, self.tb_data


### PR DESCRIPTION
This is the next PR that addresses #9, type hints added for functions in `friendly_traceback.core`.