### PR TITLE
Add type hints for `friendly_traceback.info_specific`

### DIFF
--- a/friendly_traceback/info_specific.py
+++ b/friendly_traceback/info_specific.py
@@ -4,14 +4,13 @@ Attempts to provide some specific information about the likely cause
 of a given exception.
 """
 
-import sys
 import re
+import sys
 from types import FrameType
 from typing import TYPE_CHECKING, Callable, Dict, Type, TypeVar
 
 from . import debug_helper
 from .ft_gettext import current_lang, internal_error
-
 
 if TYPE_CHECKING:
     from .core import TracebackData


### PR DESCRIPTION
This is the next PR that addresses #9, type hints added for functions in `friendly_traceback.info_specific`.

Notice that in order to avoid circular imports, `TracebackData` is imported in type checking mode only. In order to use the type hint, string literals were used (so-called forward references).