### PR TITLE
Add PEP 561 marker file

### DIFF
--- a/friendly_traceback/py.typed
+++ b/friendly_traceback/py.typed
@@ -1,0 +1,1 @@
+# Marker file for PEP 561. The ``friendly_traceback`` package uses inline types.

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,3 +48,4 @@ exclude =
 [options.package_data]
 * =
     friendly_traceback/locales/*
+friendly_traceback = py.typed


### PR DESCRIPTION
To mark the package as providing type hints, a `py.typed` file is added to the package. This way, type checkers like `mypy` or `pyre` will start using the inline types in `friendly_traceback` modules.