### PR TITLE
add type hints for `friendly_traceback` public API

### DIFF
--- a/friendly_traceback/__init__.py
+++ b/friendly_traceback/__init__.py
@@ -17,16 +17,25 @@ If you find that some additional functionality would be useful to
 have as part of the public API, please let us know.
 """
 import sys
-from typing import TYPE_CHECKING
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    Mapping,
+    Optional,
+    Sequence,
+    Union,
+)
 
 if TYPE_CHECKING:
     from _typeshed import StrPath
 else:
     import os
-    from typing import Union
 
     StrPath = Union[str, os.PathLike]
 
+Writer = Callable[[str], None]
 
 valid_version = sys.version_info.major >= 3 and sys.version_info.minor >= 6
 
@@ -75,7 +84,7 @@ def exclude_directory_from_traceback(dir_name: StrPath) -> None:
     path_info.exclude_directory_from_traceback(dir_name)
 
 
-def explain_traceback(redirect=None):
+def explain_traceback(redirect: Union[str, Writer, None] = None) -> None:
     """Replaces a standard traceback by a friendlier one, giving more
     information about a given exception than a standard traceback.
     Note that this excludes ``SystemExit`` and ``KeyboardInterrupt``
@@ -95,7 +104,7 @@ def explain_traceback(redirect=None):
     session.explain_traceback(redirect=redirect)
 
 
-def get_output(flush=True):
+def get_output(flush: bool = True) -> str:
     """Returns the result of captured output as a string which can be
     written anywhere desired.
 
@@ -105,7 +114,12 @@ def get_output(flush=True):
     return session.get_captured(flush=flush)
 
 
-def install(lang=None, redirect=None, include="explain", _debug=None):
+def install(
+    lang: Optional[str] = None,
+    redirect: Union[str, Writer, None] = None,
+    include: base_formatters.InfoKind = "explain",
+    _debug: Optional[bool] = None,
+) -> None:
     """
     Replaces ``sys.excepthook`` by friendly's own version.
     Intercepts, and provides an explanation for all Python exceptions except
@@ -127,26 +141,26 @@ def install(lang=None, redirect=None, include="explain", _debug=None):
     session.install(lang=lang, redirect=redirect, include=include)
 
 
-def is_installed():
+def is_installed() -> bool:
     """Returns True if Friendly is installed, False otherwise."""
     return session.installed
 
 
-def uninstall():
+def uninstall() -> None:
     """Resets sys.excepthook to Python's default."""
     session.uninstall()
 
 
 def run(
-    filename,
-    lang=None,
-    include=None,
-    args=None,
-    console=True,
-    formatter="repl",
-    redirect=None,
-    ipython_prompt=True,
-):  # sourcery skip: move-assign
+    filename: StrPath,
+    lang: Optional[str] = None,
+    include: Optional[base_formatters.InfoKind] = None,
+    args: Optional[Sequence[str]] = None,
+    console: bool = True,
+    formatter: Union[str, base_formatters.Formatter] = "repl",
+    redirect: Union[str, Writer, None] = None,
+    ipython_prompt: bool = True,
+) -> Optional[Dict[str, Any]]:  # sourcery skip: move-assign
     """Given a filename (relative or absolute path) ending with the ".py"
     extension, this function uses the
     more complex ``exec_code()`` to run a file.
@@ -178,7 +192,7 @@ def run(
     if include is None:
         include = "friendly_tb" if console else "explain"
     if args is not None:
-        sys.argv = [filename, *list(args)]
+        sys.argv = [str(filename), *list(args)]
     else:
         filename = Path(filename)
         if not filename.is_absolute():
@@ -210,7 +224,9 @@ def run(
         return module_globals
 
 
-def set_formatter(formatter=None):
+def set_formatter(
+    formatter: Union[str, None, base_formatters.Formatter] = None
+) -> None:
     """Sets the default formatter. If no argument is given, the default
     formatter is used.
     """
@@ -218,14 +234,14 @@ def set_formatter(formatter=None):
 
 
 def start_console(  # pragma: no cover
-    local_vars=None,
-    formatter="repl",
-    include="friendly_tb",
-    lang="en",
-    banner=None,
-    displayhook=None,
-    ipython_prompt=True,
-):
+    local_vars: Optional[Mapping[str, Any]] = None,
+    formatter: Union[str, base_formatters.Formatter] = "repl",
+    include: base_formatters.InfoKind = "friendly_tb",
+    lang: str = "en",
+    banner: Optional[str] = None,
+    displayhook: Optional[Callable[[object], Any]] = None,
+    ipython_prompt: bool = True,
+) -> None:
     """Starts a Friendly console."""
     from . import ft_console
 
@@ -252,7 +268,7 @@ def start_console(  # pragma: no cover
 # =========================================================================
 
 
-def set_lang(lang="en"):
+def set_lang(lang: str = "en") -> None:
     """Sets the language to be used for the display.
 
     If no translations exist for that language, the original
@@ -261,7 +277,7 @@ def set_lang(lang="en"):
     session.set_lang(lang=lang)
 
 
-def get_lang():
+def get_lang() -> str:
     """Returns the current language that had been set for translations.
 
     Note that the value returned may not reflect truly what is being
@@ -271,13 +287,13 @@ def get_lang():
     return session.lang
 
 
-def _include_choices():
+def _include_choices() -> str:
     """Prints the available choices for arguments to set_include()"""
     choices = [repr(key) for key in base_formatters.items_groups if key != "header"]
     return ",\n        ".join(choices)
 
 
-def set_include(include):
+def set_include(include: base_formatters.InfoKind) -> None:
     """Specifies the information to include in the traceback.
 
     The allowed values are:
@@ -291,14 +307,14 @@ if set_include.__doc__ is not None:  # protect against -OO optimization
     set_include.__doc__ = set_include.__doc__.format(choices=_include_choices())
 
 
-def get_include():
+def get_include() -> base_formatters.InfoKind:
     """Retrieves the value used to determine what to include in the
     traceback. See ``set_include()`` for details.
     """
     return session.get_include()
 
 
-def set_stream(redirect=None):
+def set_stream(redirect: Union[str, Writer, None] = None) -> None:
     """Sets the stream to which the output should be directed.
 
     If the string ``"capture"`` is given as argument, the
@@ -309,6 +325,6 @@ def set_stream(redirect=None):
     session.set_redirect(redirect=redirect)
 
 
-def get_stream():
+def get_stream() -> Writer:
     """Returns the value of the current stream used for output."""
     return session.write_err


### PR DESCRIPTION
This is the last PR that addresses #9, type hints added for functions exposed in `friendly_traceback`. Closes #9.

@aroberge I have more type hints stored locally - if you decide to have type safety for the complete code base, ping me and I will help with that. Right now it looks very good though - with a pretty strict configuration of `mypy`, about 1200 errors were reported initially. With this PR, there are only 697 errors left, mostly due to missing type hints in remaining modules. With my local type hints, this reduces to 133 errors which are mostly due to loose types and require explicit typing or explicit casts in function bodies. All in all, it looks very good, as the static analysis over typed code hasn't reveal any significant errors aside from those I've reported. This indicates high code quality! :rocket: For further reference, used `mypy==0.910` with the following configuration in `pyproject.toml`:
```toml
[tool.mypy]
files = ["friendly_traceback"]
mypy_path = ["_typeshed"]
ignore_missing_imports = false
warn_unused_configs = true
disallow_subclassing_any = true
disallow_any_generics = true
disallow_untyped_calls = true
disallow_untyped_defs = true
disallow_incomplete_defs = true
check_untyped_defs = true
disallow_untyped_decorators = true
no_implicit_optional = true
warn_redundant_casts = true
warn_unused_ignores = true
warn_return_any = true
warn_unreachable = true
show_error_codes = true
```
where `_typeshed` contains stubs for external libs that don't expose type hints.