### PR TITLE
add types for `friendly_traceback.console_helpers`

### DIFF
--- a/friendly_traceback/base_formatters.py
+++ b/friendly_traceback/base_formatters.py
@@ -31,13 +31,17 @@ This module currently contains 2 formatters:
   to print the information in a traditional console.
 """
 import sys
-from typing import Dict, List, Set
+from typing import TYPE_CHECKING, Dict, List, Set
 
 from . import debug_helper
 from .ft_gettext import current_lang
 
+if TYPE_CHECKING:
+    from .core import TracebackData
+
 if sys.version_info >= (3, 8):
-    from typing import Literal, Protocol, TypedDict
+    from types import FrameType
+    from typing import Literal, Optional, Protocol, TypedDict
 
     InclusionChoice = Literal[
         "message",
@@ -69,6 +73,9 @@ if sys.version_info >= (3, 8):
         exception_raised_source: str
         exception_raised_variables: str
         lang: str
+        _exc_instance: BaseException
+        _frame: Optional[FrameType]
+        _tb_data: "TracebackData"
 
     class Formatter(Protocol):
         def __call__(self, info: Info, include: InclusionChoice = ...) -> str:


### PR DESCRIPTION
The proposed typing leaves room for improvements, especially in introducing a proper protocol for helper functions to make the `.help` function recognizable. We could add a decorator that does explicit casts to a `Helper` protocol as suggested in https://github.com/python/mypy/issues/2087, but this would require code changes that go beyond type hints, thus leaving it out for now.