### PR TITLE
Add minimal external stubs

### DIFF
--- a/_typeshed/IPython/__init__.pyi
+++ b/_typeshed/IPython/__init__.pyi
@@ -1,0 +1,3 @@
+from typing import Any
+
+def __getattr__(name: str) -> Any: ...  # incomplete

--- a/_typeshed/asttokens.pyi
+++ b/_typeshed/asttokens.pyi
@@ -1,0 +1,3 @@
+from typing import Any
+
+def __getattr__(name: str) -> Any: ...  # incomplete

--- a/_typeshed/executing.pyi
+++ b/_typeshed/executing.pyi
@@ -1,0 +1,3 @@
+from typing import Any
+
+def __getattr__(name: str) -> Any: ...  # incomplete

--- a/_typeshed/friendly.pyi
+++ b/_typeshed/friendly.pyi
@@ -1,0 +1,3 @@
+from typing import Any
+
+def __getattr__(name: str) -> Any: ...  # incomplete

--- a/_typeshed/idlelib/__init__.pyi
+++ b/_typeshed/idlelib/__init__.pyi
@@ -1,0 +1,3 @@
+from typing import Any
+
+def __getattr__(name: str) -> Any: ...  # incomplete

--- a/_typeshed/pure_eval.pyi
+++ b/_typeshed/pure_eval.pyi
@@ -1,0 +1,3 @@
+from typing import Any
+
+def __getattr__(name: str) -> Any: ...  # incomplete

--- a/_typeshed/pygments/__init__.pyi
+++ b/_typeshed/pygments/__init__.pyi
@@ -1,0 +1,3 @@
+from typing import Any
+
+def __getattr__(name: str) -> Any: ...  # incomplete

--- a/_typeshed/stack_data/__init__.pyi
+++ b/_typeshed/stack_data/__init__.pyi
@@ -1,0 +1,3 @@
+from typing import Any
+
+def __getattr__(name: str) -> Any: ...  # incomplete

--- a/_typeshed/stack_data/core.pyi
+++ b/_typeshed/stack_data/core.pyi
@@ -1,0 +1,3 @@
+from typing import Any
+
+def __getattr__(name: str) -> Any: ...  # incomplete

--- a/_typeshed/stack_data/utils.pyi
+++ b/_typeshed/stack_data/utils.pyi
@@ -1,0 +1,3 @@
+from typing import Any
+
+def __getattr__(name: str) -> Any: ...  # incomplete


### PR DESCRIPTION
@aroberge those are minimal stubs for untyped external dependencies. They aren't required in any way, they only silence `mypy` errors about untyped dependencies like
```
friendly_traceback/path_info.py:11: error: Skipping analyzing "asttokens": found module but no type hints or library stubs  [import]
```