### PR TITLE
Move type definitions to `friendly_traceback.typing`

### DIFF
--- a/friendly_traceback/__init__.py
+++ b/friendly_traceback/__init__.py
@@ -18,7 +18,6 @@ have as part of the public API, please let us know.
 """
 import sys
 from typing import (
-    TYPE_CHECKING,
     Any,
     Callable,
     Dict,
@@ -27,15 +26,6 @@ from typing import (
     Sequence,
     Union,
 )
-
-if TYPE_CHECKING:
-    from _typeshed import StrPath
-else:
-    import os
-
-    StrPath = Union[str, os.PathLike]
-
-Writer = Callable[[str], None]
 
 valid_version = sys.version_info.major >= 3 and sys.version_info.minor >= 6
 
@@ -59,6 +49,7 @@ from . import base_formatters
 from .config import session
 from . import path_info
 from .ft_gettext import current_lang
+from .typing import Formatter, InclusionChoice, StrPath, Writer
 
 # Ensure that warnings are not shown to the end user, as they could
 # cause confusion.  Eventually, we might want to interpret them like
@@ -117,7 +108,7 @@ def get_output(flush: bool = True) -> str:
 def install(
     lang: Optional[str] = None,
     redirect: Union[str, Writer, None] = None,
-    include: base_formatters.InclusionChoice = "explain",
+    include: InclusionChoice = "explain",
     _debug: Optional[bool] = None,
 ) -> None:
     """
@@ -154,10 +145,10 @@ def uninstall() -> None:
 def run(
     filename: StrPath,
     lang: Optional[str] = None,
-    include: Optional[base_formatters.InclusionChoice] = None,
+    include: Optional[InclusionChoice] = None,
     args: Optional[Sequence[str]] = None,
     console: bool = True,
-    formatter: Union[str, base_formatters.Formatter] = "repl",
+    formatter: Union[str, Formatter] = "repl",
     redirect: Union[str, Writer, None] = None,
     ipython_prompt: bool = True,
 ) -> Optional[Dict[str, Any]]:  # sourcery skip: move-assign
@@ -224,9 +215,7 @@ def run(
         return module_globals
 
 
-def set_formatter(
-    formatter: Union[str, None, base_formatters.Formatter] = None
-) -> None:
+def set_formatter(formatter: Union[str, None, Formatter] = None) -> None:
     """Sets the default formatter. If no argument is given, the default
     formatter is used.
     """
@@ -235,8 +224,8 @@ def set_formatter(
 
 def start_console(  # pragma: no cover
     local_vars: Optional[Mapping[str, Any]] = None,
-    formatter: Union[str, base_formatters.Formatter] = "repl",
-    include: base_formatters.InclusionChoice = "friendly_tb",
+    formatter: Union[str, Formatter] = "repl",
+    include: InclusionChoice = "friendly_tb",
     lang: str = "en",
     banner: Optional[str] = None,
     displayhook: Optional[Callable[[object], Any]] = None,
@@ -293,7 +282,7 @@ def _include_choices() -> str:
     return ",\n        ".join(choices)
 
 
-def set_include(include: base_formatters.InclusionChoice) -> None:
+def set_include(include: InclusionChoice) -> None:
     """Specifies the information to include in the traceback.
 
     The allowed values are:
@@ -307,7 +296,7 @@ if set_include.__doc__ is not None:  # protect against -OO optimization
     set_include.__doc__ = set_include.__doc__.format(choices=_include_choices())
 
 
-def get_include() -> base_formatters.InclusionChoice:
+def get_include() -> InclusionChoice:
     """Retrieves the value used to determine what to include in the
     traceback. See ``set_include()`` for details.
     """

--- a/friendly_traceback/__main__.py
+++ b/friendly_traceback/__main__.py
@@ -126,7 +126,7 @@ parser.add_argument(
 )
 
 
-def main():
+def main() -> None:
     _ = current_lang.translate
     args = parser.parse_args()
     if args.version:  # pragma: no cover

--- a/friendly_traceback/base_formatters.py
+++ b/friendly_traceback/base_formatters.py
@@ -30,64 +30,11 @@ This module currently contains 2 formatters:
   embedded as a code-block in a file (such as .rst). It can also be used
   to print the information in a traditional console.
 """
-import sys
-from typing import TYPE_CHECKING, Dict, List, Set
+from typing import Dict, List, Set
 
 from . import debug_helper
 from .ft_gettext import current_lang
-
-if TYPE_CHECKING:
-    from .core import TracebackData
-
-if sys.version_info >= (3, 8):
-    from types import FrameType
-    from typing import Literal, Optional, Protocol, TypedDict
-
-    InclusionChoice = Literal[
-        "message",
-        "hint",
-        "what",
-        "why",
-        "where",
-        "friendly_tb",
-        "python_tb",
-        "debug_tb",
-        "explain",
-        "no_tb",
-    ]
-
-    class Info(TypedDict, total=False):
-        message: str
-        original_python_traceback: str
-        simulated_python_traceback: str
-        shortened_traceback: str
-        suggest: str
-        generic: str
-        parsing_error: str
-        parsing_error_source: str
-        cause: str
-        last_call_header: str
-        last_call_source: str
-        last_call_variables: str
-        exception_raised_header: str
-        exception_raised_source: str
-        exception_raised_variables: str
-        lang: str
-        _exc_instance: BaseException
-        _frame: Optional[FrameType]
-        _tb_data: "TracebackData"
-
-    class Formatter(Protocol):
-        def __call__(self, info: Info, include: InclusionChoice = ...) -> str:
-            ...
-
-
-else:
-    from typing import Callable
-
-    InclusionChoice = str
-    Info = Dict[str, str]
-    Formatter = Callable[[Info, InclusionChoice], str]
+from .typing import InclusionChoice, Info
 
 
 # The following is the order in which the various items, if they exist

--- a/friendly_traceback/config.py
+++ b/friendly_traceback/config.py
@@ -4,12 +4,11 @@ Keeps tabs of all settings.
 """
 import sys
 import types
-from typing import List, Optional, Type, TypeVar, Union
+from typing import List, Optional, Type, Union
 
-from . import Writer, base_formatters, core, debug_helper
+from . import base_formatters, core, debug_helper
 from .ft_gettext import current_lang
-
-_E = TypeVar("_E", bound=BaseException)
+from .typing import Formatter, InclusionChoice, Info, Writer, _E
 
 
 def _write_err(text: Optional[str]) -> None:  # pragma: no cover
@@ -32,11 +31,11 @@ class _State:
         self._captured: List[str] = []
         self.write_err: Writer = _write_err
         self.installed: bool = False
-        self.formatter: base_formatters.Formatter = base_formatters.repl
-        self.saved_info: List[base_formatters.Info] = []
+        self.formatter: Formatter = base_formatters.repl
+        self.saved_info: List[Info] = []
         self.friendly_info: List[core.FriendlyTraceback] = []
         # TODO: is having both saved_info and friendly_info redundant?
-        self.include: base_formatters.InclusionChoice = "explain"
+        self.include: InclusionChoice = "explain"
         self.lang: str = "en"
         self.install_gettext(self.lang)
         # Console; if ipython_prompt == True, prompt = '[digit]'
@@ -101,17 +100,15 @@ class _State:
         current_lang.install(lang)
         self.lang = lang
 
-    def set_include(self, include: base_formatters.InclusionChoice) -> None:
+    def set_include(self, include: InclusionChoice) -> None:
         if include not in base_formatters.items_groups:  # pragma: no cover
             raise ValueError(f"{include} is not a valid value.")
         self.include = include
 
-    def get_include(self) -> base_formatters.InclusionChoice:
+    def get_include(self) -> InclusionChoice:
         return self.include
 
-    def set_formatter(
-        self, formatter: Union[str, None, base_formatters.Formatter] = None
-    ) -> None:
+    def set_formatter(self, formatter: Union[str, None, Formatter] = None) -> None:
         """Sets the default formatter. If no argument is given, the default
         formatter is used.
         """
@@ -129,7 +126,7 @@ class _State:
         self,
         lang: Optional[str] = None,
         redirect: Union[str, Writer, None] = None,
-        include: base_formatters.InclusionChoice = "explain",
+        include: InclusionChoice = "explain",
     ) -> None:
         """Replaces sys.excepthook by friendly's own version."""
         _ = current_lang.translate

--- a/friendly_traceback/console_helpers.py
+++ b/friendly_traceback/console_helpers.py
@@ -14,20 +14,14 @@ import friendly_traceback
 
 from friendly_traceback import debug_helper, base_formatters, __version__
 from friendly_traceback.config import session
+from friendly_traceback.core import TracebackData
 from friendly_traceback.info_generic import get_generic_explanation
 from friendly_traceback.path_info import show_paths
 from friendly_traceback.ft_gettext import current_lang
 from friendly_traceback.syntax_errors.source_info import Statement
+from friendly_traceback.typing import InclusionChoice, Site
 from friendly_traceback.utils import add_rich_repr
 
-if sys.version_info >= (3, 8):
-    from typing import Literal
-    from friendly_traceback.core import TracebackData
-
-    Site = Literal["friendly", "python", "bug", "email", "warnings"]
-
-else:
-    Site = str
 
 _ = current_lang.translate
 
@@ -52,7 +46,7 @@ def back() -> None:
             session.friendly_info[-1].recompile_info()
 
 
-def explain(include: base_formatters.InclusionChoice = "explain") -> None:
+def explain(include: InclusionChoice = "explain") -> None:
     """Shows the previously recorded traceback info again,
     with the option to specify different items to include.
     For example, ``explain("why")`` is equivalent to ``why()``.
@@ -292,7 +286,7 @@ def _get_statement() -> Optional[Statement]:  # pragma: no cover
     return
 
 
-def _get_tb_data() -> Optional["TracebackData"]:  # pragma: no cover
+def _get_tb_data() -> Optional[TracebackData]:  # pragma: no cover
     """This returns the TracebackData instance containing all the
     information we have obtained.
 

--- a/friendly_traceback/core.py
+++ b/friendly_traceback/core.py
@@ -12,7 +12,7 @@ import inspect
 import re
 import traceback
 import types
-from typing import List, Optional, Sequence, Tuple, Type, TypeVar
+from typing import List, Optional, Sequence, Tuple, Type
 
 from itertools import dropwhile
 
@@ -21,7 +21,6 @@ from . import info_generic
 from . import info_specific
 from . import info_variables
 
-from .base_formatters import Info
 from .frame_info import FrameInfo
 from .ft_gettext import current_lang
 
@@ -32,14 +31,12 @@ from .syntax_errors import analyze_syntax
 from .syntax_errors import indentation_error
 from .syntax_errors import source_info
 from . import token_utils
+from .typing import Info, _E
 
 try:
     import executing  # noqa
 except ImportError:  # pragma: no cover
     pass  # ignore errors when processed by Sphinx
-
-
-_E = TypeVar("_E", bound=BaseException)
 
 
 STR_FAILED = "<exception str() failed>"  # Same as Python

--- a/friendly_traceback/ft_console.py
+++ b/friendly_traceback/ft_console.py
@@ -17,10 +17,10 @@ import codeop  # need to import to exclude from tracebacks
 import friendly_traceback
 
 from . import source_cache
-from .base_formatters import Formatter, InclusionChoice
 from .console_helpers import helpers
 from .ft_gettext import current_lang
 from .config import session
+from .typing import Formatter, InclusionChoice
 
 
 def type_friendly() -> str:

--- a/friendly_traceback/ft_gettext.py
+++ b/friendly_traceback/ft_gettext.py
@@ -22,11 +22,10 @@ gettext.translation() is the class-based API for gettext.
 
 import gettext
 import os
-from typing import Callable, Optional
+from typing import Optional
 
 from . import debug_helper
-
-Translator = Callable[[str], str]
+from .typing import Translator
 
 
 class LangState:

--- a/friendly_traceback/info_generic.py
+++ b/friendly_traceback/info_generic.py
@@ -6,9 +6,7 @@ import inspect
 from typing import Any, Callable, Dict, Type
 
 from .ft_gettext import current_lang, no_information
-
-
-GenericExplain = Callable[[], str]
+from .typing import GenericExplain
 
 
 GENERIC: Dict[Type[BaseException], GenericExplain] = {}

--- a/friendly_traceback/info_specific.py
+++ b/friendly_traceback/info_specific.py
@@ -5,31 +5,15 @@ of a given exception.
 """
 
 import re
-import sys
 from types import FrameType
-from typing import TYPE_CHECKING, Callable, Dict, Type, TypeVar
+from typing import TYPE_CHECKING, Callable, Dict, Type
 
 from . import debug_helper
 from .ft_gettext import current_lang, internal_error
+from .typing import CauseInfo, Explain, _E
 
 if TYPE_CHECKING:
     from .core import TracebackData
-
-if sys.version_info >= (3, 8):
-    from typing import TypedDict
-
-    class CauseInfo(TypedDict, total=False):
-        cause: str
-        suggest: str
-
-
-else:
-    CauseInfo = Dict[str, str]
-
-
-_E = TypeVar("_E", bound=BaseException)
-
-Explain = Callable[[_E, FrameType, "TracebackData"], CauseInfo]
 
 
 get_cause: Dict[Type[BaseException], Explain[BaseException]] = {}

--- a/friendly_traceback/info_variables.py
+++ b/friendly_traceback/info_variables.py
@@ -14,6 +14,7 @@ from . import token_utils
 
 from .path_info import path_utils
 from .ft_gettext import current_lang
+from .typing import ObjectsInfo, ScopeKind, SimilarNamesInfo
 
 # third-party
 try:
@@ -21,31 +22,6 @@ try:
     from pure_eval import Evaluator, group_expressions  # noqa
 except ImportError:  # pragma: no cover
     pass  # ignore errors when processed by Sphinx
-
-
-if sys.version_info >= (3, 8):
-    from typing import Literal, Tuple, TypedDict
-
-    ScopeKind = Literal["local", "global", "nonlocal"]
-
-    ObjectsInfo = TypedDict(
-        "ObjectsInfo",
-        {
-            "locals": List[Tuple[str, str, Any]],
-            "globals": List[Tuple[str, str, Any]],
-            "builtins": List[Tuple[str, str, Any]],
-            "expressions": List[Tuple[str, Any]],
-            "name, obj": List[Tuple[str, Any]],
-        },
-    )
-    SimilarNamesInfo = TypedDict(
-        "SimilarNamesInfo",
-        {"locals": List[str], "globals": List[str], "builtins": List[str], "best": Any},
-    )
-else:
-    ScopeKind = str
-    ObjectsInfo = Dict[str, List[Any]]
-    SimilarNamesInfo = Dict[str, List[str]]
 
 
 INDENT = " " * 8

--- a/friendly_traceback/path_info.py
+++ b/friendly_traceback/path_info.py
@@ -9,16 +9,10 @@ it might be desirable to exclude additional files.
 import os
 import sys
 import asttokens  # Only use it as a representative to find site-packages
-from typing import TYPE_CHECKING, Set, TypeVar
+from typing import Set, TypeVar
 
 from .ft_gettext import current_lang
-
-if TYPE_CHECKING:
-    from _typeshed import StrPath
-else:
-    from typing import Union
-
-    StrPath = Union[str, os.PathLike]
+from .typing import StrPath
 
 
 EXCLUDED_FILE_PATH: Set[str] = set()

--- a/friendly_traceback/typing.py
+++ b/friendly_traceback/typing.py
@@ -1,0 +1,99 @@
+"""Custom type definitions and shortcuts for annotating ``friendly_traceback``."""
+
+import os
+import sys
+from types import FrameType
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Union, Tuple, TypeVar
+
+
+if TYPE_CHECKING:
+    from _typeshed import StrPath
+    from .core import TracebackData
+else:
+    StrPath = Union[str, os.PathLike]
+
+
+_E = TypeVar("_E", bound=BaseException)
+
+
+if sys.version_info >= (3, 8):
+    from types import FrameType
+    from typing import Literal, Optional, Protocol, TypedDict
+
+    InclusionChoice = Literal[
+        "message",
+        "hint",
+        "what",
+        "why",
+        "where",
+        "friendly_tb",
+        "python_tb",
+        "debug_tb",
+        "explain",
+        "no_tb",
+    ]
+
+    class Info(TypedDict, total=False):
+        message: str
+        original_python_traceback: str
+        simulated_python_traceback: str
+        shortened_traceback: str
+        suggest: str
+        generic: str
+        parsing_error: str
+        parsing_error_source: str
+        cause: str
+        last_call_header: str
+        last_call_source: str
+        last_call_variables: str
+        exception_raised_header: str
+        exception_raised_source: str
+        exception_raised_variables: str
+        lang: str
+        _exc_instance: BaseException
+        _frame: Optional[FrameType]
+        _tb_data: "TracebackData"
+
+    class Formatter(Protocol):
+        def __call__(self, info: Info, include: InclusionChoice = ...) -> str:
+            ...
+
+    class CauseInfo(TypedDict, total=False):
+        cause: str
+        suggest: str
+
+    Site = Literal["friendly", "python", "bug", "email", "warnings"]
+
+    ScopeKind = Literal["local", "global", "nonlocal"]
+
+    ObjectsInfo = TypedDict(
+        "ObjectsInfo",
+        {
+            "locals": List[Tuple[str, str, Any]],
+            "globals": List[Tuple[str, str, Any]],
+            "builtins": List[Tuple[str, str, Any]],
+            "expressions": List[Tuple[str, Any]],
+            "name, obj": List[Tuple[str, Any]],
+        },
+    )
+    SimilarNamesInfo = TypedDict(
+        "SimilarNamesInfo",
+        {"locals": List[str], "globals": List[str], "builtins": List[str], "best": Any},
+    )
+
+else:
+    InclusionChoice = str
+    Info = Dict[str, str]
+    Formatter = Callable[[Info, InclusionChoice], str]
+    Site = str
+    CauseInfo = Dict[str, str]
+    ScopeKind = str
+    ObjectsInfo = Dict[str, List[Any]]
+    SimilarNamesInfo = Dict[str, List[str]]
+
+
+Explain = Callable[[_E, FrameType, "TracebackData"], CauseInfo]
+GenericExplain = Callable[[], str]
+Parser = Callable[[Union[str, BaseException], FrameType, "TracebackData"], CauseInfo]
+Translator = Callable[[str], str]
+Writer = Callable[[str], None]

--- a/friendly_traceback/typing.py
+++ b/friendly_traceback/typing.py
@@ -17,7 +17,6 @@ _E = TypeVar("_E", bound=BaseException)
 
 
 if sys.version_info >= (3, 8):
-    from types import FrameType
     from typing import Literal, Optional, Protocol, TypedDict
 
     InclusionChoice = Literal[

--- a/friendly_traceback/utils.py
+++ b/friendly_traceback/utils.py
@@ -13,15 +13,10 @@ import pure_eval
 
 from . import debug_helper
 from .ft_gettext import internal_error, no_information
-from .info_specific import CauseInfo
+from .typing import CauseInfo, Parser
 
 if TYPE_CHECKING:
     from .core import TracebackData
-
-
-Parser = Callable[
-    [Union[str, BaseException], types.FrameType, "TracebackData"], CauseInfo
-]
 
 
 class RuntimeMessageParser:


### PR DESCRIPTION
All type definitions are moved to a new module `friendly_traceback.typing` that should contain nothing else. This avoids importing modules for the sake of type checking only and reduces the possibility of import cycles, also it removes most of the `if TYPE_CHECKING` and `if sys.version_info >= ...` fuzz from the code, restoring initial code readability before type checking was introduced.