### PR TITLE
Add `isort` to code formatting tools

### DIFF
--- a/.github/workflows/full_tests.yml
+++ b/.github/workflows/full_tests.yml
@@ -42,4 +42,3 @@ jobs:
       - name: run ${{ matrix.tox.env }}
         run: |
           tox -q -p all
-

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,16 @@
 repos:
 -   repo: https://github.com/ambv/black
-    rev: 19.3b0
+    rev: 20.8b1
     hooks:
     - id: black
       language_version: python3
       exclude: ^tests/
 -   repo: https://gitlab.com/pycqa/flake8
-    rev: 3.8.4
+    rev: 3.9.2
     hooks:
     -   id: flake8
+-   repo: https://github.com/timothycrosley/isort
+    rev: 5.9.3
+    hooks:
+    -   id: isort
+        exclude: ^tests/

--- a/friendly_traceback/__init__.py
+++ b/friendly_traceback/__init__.py
@@ -17,15 +17,7 @@ If you find that some additional functionality would be useful to
 have as part of the public API, please let us know.
 """
 import sys
-from typing import (
-    Any,
-    Callable,
-    Dict,
-    Mapping,
-    Optional,
-    Sequence,
-    Union,
-)
+from typing import Any, Callable, Dict, Mapping, Optional, Sequence, Union
 
 valid_version = sys.version_info.major >= 3 and sys.version_info.minor >= 6
 
@@ -43,11 +35,8 @@ import inspect
 import warnings as _warnings
 from pathlib import Path
 
-from . import debug_helper
-from . import editors_helpers
-from . import base_formatters
+from . import base_formatters, debug_helper, editors_helpers, path_info
 from .config import session
-from . import path_info
 from .ft_gettext import current_lang
 from .typing import Formatter, InclusionChoice, StrPath, Writer
 

--- a/friendly_traceback/__main__.py
+++ b/friendly_traceback/__main__.py
@@ -12,17 +12,19 @@ import argparse
 import platform
 import runpy
 import sys
-
 from importlib import import_module
 from pathlib import Path
 
-from . import ft_console
-from . import debug_helper
+from . import (
+    __version__,
+    debug_helper,
+    exclude_file_from_traceback,
+    explain_traceback,
+    ft_console,
+    install,
+    set_formatter,
+)
 from .ft_gettext import current_lang
-
-from . import explain_traceback, exclude_file_from_traceback, install
-from . import set_formatter, __version__
-
 
 versions = "Friendly-traceback version {}. [Python version: {}]\n".format(
     __version__, platform.python_version()

--- a/friendly_traceback/base_formatters.py
+++ b/friendly_traceback/base_formatters.py
@@ -36,7 +36,6 @@ from . import debug_helper
 from .ft_gettext import current_lang
 from .typing import InclusionChoice, Info
 
-
 # The following is the order in which the various items, if they exist
 # and have been selected to be printed, would be printed.
 # If you are writing a custom formatter, this should be taken as the

--- a/friendly_traceback/config.py
+++ b/friendly_traceback/config.py
@@ -8,7 +8,7 @@ from typing import List, Optional, Type, Union
 
 from . import base_formatters, core, debug_helper
 from .ft_gettext import current_lang
-from .typing import Formatter, InclusionChoice, Info, Writer, _E
+from .typing import _E, Formatter, InclusionChoice, Info, Writer
 
 
 def _write_err(text: Optional[str]) -> None:  # pragma: no cover

--- a/friendly_traceback/console_helpers.py
+++ b/friendly_traceback/console_helpers.py
@@ -9,19 +9,18 @@ environments such as in a Jupyter notebook.
 import inspect
 import sys
 import types
-from typing import Any, Callable, Dict, Iterable, List, Optional, Union, Type
-import friendly_traceback
+from typing import Any, Callable, Dict, Iterable, List, Optional, Type, Union
 
-from friendly_traceback import debug_helper, base_formatters, __version__
+import friendly_traceback
+from friendly_traceback import __version__, base_formatters, debug_helper
 from friendly_traceback.config import session
 from friendly_traceback.core import TracebackData
+from friendly_traceback.ft_gettext import current_lang
 from friendly_traceback.info_generic import get_generic_explanation
 from friendly_traceback.path_info import show_paths
-from friendly_traceback.ft_gettext import current_lang
 from friendly_traceback.syntax_errors.source_info import Statement
 from friendly_traceback.typing import InclusionChoice, Site
 from friendly_traceback.utils import add_rich_repr
-
 
 _ = current_lang.translate
 

--- a/friendly_traceback/core.py
+++ b/friendly_traceback/core.py
@@ -12,26 +12,17 @@ import inspect
 import re
 import traceback
 import types
+from itertools import dropwhile
 from typing import List, Optional, Sequence, Tuple, Type
 
-from itertools import dropwhile
-
-from . import debug_helper
-from . import info_generic
-from . import info_specific
-from . import info_variables
-
+from . import debug_helper, info_generic, info_specific, info_variables, token_utils
 from .frame_info import FrameInfo
 from .ft_gettext import current_lang
-
-from .path_info import is_excluded_file, EXCLUDED_FILE_PATH, path_utils
+from .path_info import EXCLUDED_FILE_PATH, is_excluded_file, path_utils
 from .runtime_errors import name_error
 from .source_cache import cache
-from .syntax_errors import analyze_syntax
-from .syntax_errors import indentation_error
-from .syntax_errors import source_info
-from . import token_utils
-from .typing import Info, _E
+from .syntax_errors import analyze_syntax, indentation_error, source_info
+from .typing import _E, Info
 
 try:
     import executing  # noqa

--- a/friendly_traceback/editors_helpers.py
+++ b/friendly_traceback/editors_helpers.py
@@ -13,9 +13,9 @@ it can be determined if it should be added to the public API.
 """
 import sys
 
-from .source_cache import cache
-from .ft_gettext import current_lang
 from .config import session
+from .ft_gettext import current_lang
+from .source_cache import cache
 
 
 def check_syntax(

--- a/friendly_traceback/frame_info.py
+++ b/friendly_traceback/frame_info.py
@@ -6,6 +6,7 @@ from stack_data import Line
 from stack_data.utils import cached_property
 
 from friendly_traceback import token_utils
+
 from . import debug_helper
 from .ft_gettext import current_lang
 from .source_cache import cache

--- a/friendly_traceback/ft_console.py
+++ b/friendly_traceback/ft_console.py
@@ -5,21 +5,21 @@ ft_console.py
 Adaptation of Python's console found in code.py so that it can be
 used to show some "friendly" tracebacks.
 """
+import codeop  # need to import to exclude from tracebacks
 import os
 import platform
 import sys
 import traceback
 import types
-from typing import Any, Callable, Mapping, Optional, Union
 from code import InteractiveConsole
-import codeop  # need to import to exclude from tracebacks
+from typing import Any, Callable, Mapping, Optional, Union
 
 import friendly_traceback
 
 from . import source_cache
+from .config import session
 from .console_helpers import helpers
 from .ft_gettext import current_lang
-from .config import session
 from .typing import Formatter, InclusionChoice
 
 

--- a/friendly_traceback/info_generic.py
+++ b/friendly_traceback/info_generic.py
@@ -8,7 +8,6 @@ from typing import Any, Callable, Dict, Type
 from .ft_gettext import current_lang, no_information
 from .typing import GenericExplain
 
-
 GENERIC: Dict[Type[BaseException], GenericExplain] = {}
 SUBCLASS: Dict[Any, Any] = {}
 

--- a/friendly_traceback/info_specific.py
+++ b/friendly_traceback/info_specific.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Callable, Dict, Type
 
 from . import debug_helper
 from .ft_gettext import current_lang, internal_error
-from .typing import CauseInfo, Explain, _E
+from .typing import _E, CauseInfo, Explain
 
 if TYPE_CHECKING:
     from .core import TracebackData

--- a/friendly_traceback/info_variables.py
+++ b/friendly_traceback/info_variables.py
@@ -9,11 +9,9 @@ import sys
 import types
 from typing import Any, Dict, List
 
-from . import utils
-from . import token_utils
-
-from .path_info import path_utils
+from . import token_utils, utils
 from .ft_gettext import current_lang
+from .path_info import path_utils
 from .typing import ObjectsInfo, ScopeKind, SimilarNamesInfo
 
 # third-party

--- a/friendly_traceback/path_info.py
+++ b/friendly_traceback/path_info.py
@@ -8,12 +8,12 @@ it might be desirable to exclude additional files.
 """
 import os
 import sys
-import asttokens  # Only use it as a representative to find site-packages
 from typing import Set, TypeVar
+
+import asttokens  # Only use it as a representative to find site-packages
 
 from .ft_gettext import current_lang
 from .typing import StrPath
-
 
 EXCLUDED_FILE_PATH: Set[str] = set()
 EXCLUDED_DIR_NAMES: Set[str] = set()

--- a/friendly_traceback/runtime_errors/attribute_error.py
+++ b/friendly_traceback/runtime_errors/attribute_error.py
@@ -6,16 +6,13 @@ import sys
 from types import FrameType
 from typing import Any, Iterable, List, Optional, Sequence
 
-from .. import console_helpers
-from ..ft_gettext import current_lang, no_information, please_report, internal_error
-from ..utils import get_similar_words, list_to_string
-from ..path_info import path_utils
-from .. import info_variables
-from .. import debug_helper
-from . import stdlib_modules
-
+from .. import console_helpers, debug_helper, info_variables
 from ..core import TracebackData
+from ..ft_gettext import current_lang, internal_error, no_information, please_report
+from ..path_info import path_utils
 from ..typing import CauseInfo
+from ..utils import get_similar_words, list_to_string
+from . import stdlib_modules
 
 
 def get_cause(

--- a/friendly_traceback/runtime_errors/import_error.py
+++ b/friendly_traceback/runtime_errors/import_error.py
@@ -5,12 +5,12 @@ import sys
 from types import FrameType
 from typing import List, Optional, Tuple
 
-from ..ft_gettext import current_lang, please_report
-from ..utils import get_similar_words, list_to_string, RuntimeMessageParser
-from ..path_info import path_utils
 from .. import debug_helper
 from ..core import TracebackData
+from ..ft_gettext import current_lang, please_report
+from ..path_info import path_utils
 from ..typing import CauseInfo
+from ..utils import RuntimeMessageParser, get_similar_words, list_to_string
 
 parser = RuntimeMessageParser()
 

--- a/friendly_traceback/runtime_errors/index_error.py
+++ b/friendly_traceback/runtime_errors/index_error.py
@@ -6,10 +6,9 @@ from types import FrameType
 
 import pure_eval
 
-from .. import debug_helper
-from .. import info_variables
-from ..ft_gettext import current_lang, no_information, internal_error
+from .. import debug_helper, info_variables
 from ..core import TracebackData
+from ..ft_gettext import current_lang, internal_error, no_information
 from ..typing import CauseInfo
 
 

--- a/friendly_traceback/runtime_errors/key_error.py
+++ b/friendly_traceback/runtime_errors/key_error.py
@@ -2,12 +2,10 @@ import ast
 from types import FrameType
 from typing import Any, Optional, Tuple
 
-from ..ft_gettext import current_lang, please_report
-from .. import info_variables
-from .. import utils
+from .. import info_variables, utils
 from ..core import TracebackData
+from ..ft_gettext import current_lang, please_report
 from ..typing import CauseInfo
-
 from ..utils import RuntimeMessageParser
 
 parser = RuntimeMessageParser()

--- a/friendly_traceback/runtime_errors/module_not_found_error.py
+++ b/friendly_traceback/runtime_errors/module_not_found_error.py
@@ -4,12 +4,12 @@ import re
 import sys
 from types import FrameType
 
-from . import stdlib_modules
 from .. import debug_helper
-from ..ft_gettext import current_lang
-from ..utils import get_similar_words, list_to_string, RuntimeMessageParser
 from ..core import TracebackData
+from ..ft_gettext import current_lang
 from ..typing import CauseInfo
+from ..utils import RuntimeMessageParser, get_similar_words, list_to_string
+from . import stdlib_modules
 
 parser = RuntimeMessageParser()
 

--- a/friendly_traceback/runtime_errors/name_error.py
+++ b/friendly_traceback/runtime_errors/name_error.py
@@ -3,13 +3,10 @@ import re
 from types import FrameType
 from typing import TYPE_CHECKING, Optional, Tuple
 
-from ..ft_gettext import current_lang, no_information, internal_error
-from . import stdlib_modules
-from .. import info_variables
-from .. import debug_helper
-from .. import token_utils
-from .. import utils
+from .. import debug_helper, info_variables, token_utils, utils
+from ..ft_gettext import current_lang, internal_error, no_information
 from ..typing import CauseInfo, Parser, SimilarNamesInfo
+from . import stdlib_modules
 
 if TYPE_CHECKING:
     from ..core import TracebackData

--- a/friendly_traceback/runtime_errors/os_error.py
+++ b/friendly_traceback/runtime_errors/os_error.py
@@ -1,8 +1,8 @@
 """Only identifying failed connection to a server for now."""
 from types import FrameType
 
-from ..ft_gettext import current_lang, no_information
 from ..core import TracebackData
+from ..ft_gettext import current_lang, no_information
 from ..typing import CauseInfo
 
 

--- a/friendly_traceback/runtime_errors/type_error.py
+++ b/friendly_traceback/runtime_errors/type_error.py
@@ -8,11 +8,9 @@ import re
 from types import FrameType
 from typing import Any, List, Optional, Tuple, Type
 
-from ..ft_gettext import current_lang, no_information
-from .. import info_variables
-from .. import token_utils
-from .. import utils
+from .. import info_variables, token_utils, utils
 from ..core import TracebackData
+from ..ft_gettext import current_lang, no_information
 from ..typing import CauseInfo
 
 convert_type = info_variables.convert_type

--- a/friendly_traceback/runtime_errors/unbound_local_error.py
+++ b/friendly_traceback/runtime_errors/unbound_local_error.py
@@ -3,10 +3,9 @@
 import re
 from types import FrameType
 
-from ..ft_gettext import current_lang, no_information
-from .. import info_variables
-from .. import debug_helper
+from .. import debug_helper, info_variables
 from ..core import TracebackData
+from ..ft_gettext import current_lang, no_information
 from ..typing import CauseInfo, SimilarNamesInfo
 
 

--- a/friendly_traceback/runtime_errors/value_error.py
+++ b/friendly_traceback/runtime_errors/value_error.py
@@ -9,11 +9,9 @@ import re
 from types import FrameType
 from typing import Any, Optional, Tuple
 
-from ..ft_gettext import current_lang
-from .. import info_variables
-from .. import token_utils
-from .. import utils
+from .. import info_variables, token_utils, utils
 from ..core import TracebackData
+from ..ft_gettext import current_lang
 from ..typing import CauseInfo
 
 convert_type = info_variables.convert_type

--- a/friendly_traceback/runtime_errors/zero_division_error.py
+++ b/friendly_traceback/runtime_errors/zero_division_error.py
@@ -1,11 +1,11 @@
 from types import FrameType
 from typing import SupportsInt, Union
 
+from .. import debug_helper
 from ..core import TracebackData
 from ..ft_gettext import current_lang
-from .. import debug_helper
-from ..utils import RuntimeMessageParser
 from ..typing import CauseInfo
+from ..utils import RuntimeMessageParser
 
 parser = RuntimeMessageParser()
 

--- a/friendly_traceback/syntax_errors/analyze_syntax.py
+++ b/friendly_traceback/syntax_errors/analyze_syntax.py
@@ -17,9 +17,9 @@ incorrect information.
 """
 
 from friendly_traceback.ft_gettext import current_lang, internal_error
-from . import statement_analyzer
-from . import message_analyzer
+
 from .. import debug_helper
+from . import message_analyzer, statement_analyzer
 
 
 def unknown_cause():

--- a/friendly_traceback/syntax_errors/error_in_def.py
+++ b/friendly_traceback/syntax_errors/error_in_def.py
@@ -4,10 +4,9 @@ associated with a 'def' statement.
 import platform
 import sys
 
-from . import fixers
+from .. import debug_helper, utils
 from ..ft_gettext import current_lang, internal_error
-from .. import debug_helper
-from .. import utils
+from . import fixers
 
 STATEMENT_ANALYZERS = []
 

--- a/friendly_traceback/syntax_errors/fixers.py
+++ b/friendly_traceback/syntax_errors/fixers.py
@@ -1,7 +1,6 @@
 """Various functions used to find fixes to SyntaxErrors"""
 
-from .. import debug_helper
-from .. import token_utils
+from .. import debug_helper, token_utils
 
 
 def replace_token(tokens, original_token, new_token_string):

--- a/friendly_traceback/syntax_errors/message_analyzer.py
+++ b/friendly_traceback/syntax_errors/message_analyzer.py
@@ -4,17 +4,14 @@ Collection of functions that examine SyntaxError messages and
 return relevant information to users.
 """
 import __future__
+
 import ast
 import re
 import sys
 
-from . import fixers
-from . import syntax_utils
-from . import statement_analyzer
-from . import error_in_def
-from .. import debug_helper
-from .. import utils
+from .. import debug_helper, utils
 from ..ft_gettext import current_lang, please_report
+from . import error_in_def, fixers, statement_analyzer, syntax_utils
 
 MESSAGE_ANALYZERS = []
 

--- a/friendly_traceback/syntax_errors/source_info.py
+++ b/friendly_traceback/syntax_errors/source_info.py
@@ -2,11 +2,9 @@
 is relevant to the analysis of SyntaxErrors.
 """
 
+from .. import debug_helper, token_utils
 from ..source_cache import cache
 from .syntax_utils import matching_brackets
-from .. import debug_helper
-from .. import token_utils
-
 
 # During the analysis for finding the cause of the error, we typically examine
 # a "bad token" identified by Python as the cause of the error and often

--- a/friendly_traceback/syntax_errors/statement_analyzer.py
+++ b/friendly_traceback/syntax_errors/statement_analyzer.py
@@ -5,13 +5,9 @@
 import keyword
 import sys
 
-from . import error_in_def
-from . import fixers
-from . import syntax_utils
+from .. import debug_helper, token_utils, utils
 from ..ft_gettext import current_lang, internal_error
-from .. import debug_helper
-from .. import token_utils
-from .. import utils
+from . import error_in_def, fixers, syntax_utils
 
 STATEMENT_ANALYZERS = []
 

--- a/friendly_traceback/syntax_errors/syntax_utils.py
+++ b/friendly_traceback/syntax_errors/syntax_utils.py
@@ -2,7 +2,6 @@
 
 import unicodedata
 
-
 from ..ft_gettext import current_lang
 
 

--- a/friendly_traceback/token_utils.py
+++ b/friendly_traceback/token_utils.py
@@ -9,7 +9,7 @@ import keyword
 import sys
 import tokenize as py_tokenize
 from io import StringIO
-from typing import Any, List, Iterable, Sequence, Tuple, Union
+from typing import Any, Iterable, List, Sequence, Tuple, Union
 
 from . import debug_helper
 

--- a/friendly_traceback/typing.py
+++ b/friendly_traceback/typing.py
@@ -3,11 +3,11 @@
 import os
 import sys
 from types import FrameType
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Union, Tuple, TypeVar
-
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Tuple, TypeVar, Union
 
 if TYPE_CHECKING:
     from _typeshed import StrPath
+
     from .core import TracebackData
 else:
     StrPath = Union[str, os.PathLike]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,3 +20,8 @@ warn_unused_ignores = true
 warn_return_any = true
 warn_unreachable = true
 show_error_codes = true
+
+[tool.isort]
+profile = "black"
+known_first_party = ["friendly", "friendly_traceback"]
+known_third_party = ["asttokens", "executing", "pure_eval", "stack_data"]

--- a/tox.ini
+++ b/tox.ini
@@ -28,3 +28,7 @@ commands = flake8 friendly_traceback
 [testenv:black]
 deps = black
 commands = black --check --diff friendly_traceback
+
+[testenv:isort]
+deps = isort
+commands = isort --check-only --df friendly_traceback


### PR DESCRIPTION
@aroberge this is merely a suggestion! [`isort`](https://pycqa.github.io/isort/) takes care of the unification of imports ordering. E.g. it ensures that stdlib imports always come before third-party imports, or does sorting of import lines. I like using this tool in combination with `black` so I can import stuff arbitrarily in the code, and later `isort` takes care of rearranging the imports or merge the import lines according to selected code style. For this PR, I have set up the initial configuration of `isort` to comply to the code style defined by `black`.