### PR TITLE
Use original Source to get statement text

### DIFF
--- a/friendly_traceback/utils.py
+++ b/friendly_traceback/utils.py
@@ -8,7 +8,6 @@ import types
 import uuid
 from typing import Any, Iterable, List, Tuple
 
-import executing
 import pure_eval
 
 from .tb_data import TracebackData  # purely for type checking

--- a/friendly_traceback/utils.py
+++ b/friendly_traceback/utils.py
@@ -213,9 +213,9 @@ def get_bad_statement(tb_data: TracebackData) -> str:
     """This function attempts to recover a complete statement
     even if it spans multiple lines."""
     try:
-        st = executing.executing.statement_containing_node(tb_data.node)
-        source = executing.executing.Source.for_frame(tb_data.exception_frame)
-        return source.asttokens().get_text(st)
+        ex = tb_data.records[-1].executing
+        [statement] = ex.statements
+        return ex.source.asttokens().get_text(statement)
     except Exception:  # noqa
         if hasattr(tb_data, "original_bad_line"):
             return tb_data.original_bad_line


### PR DESCRIPTION
While testing https://github.com/alexmojaki/stack_data/pull/41 here, I found a problem. `tb_data.node` comes from `stack_data.Source`, but then `executing.Source` (the base class) is used with it. Different Source classes maintain different internal metadata and are not necessarily compatible. In this particular case it's an upcoming incompatibility related to asttokens, but it could be anything. Besides, subclasses can have extra metadata that could be useful. You may find it useful someday to create your own subclass of `stack_data.Source` to add your own per-file cached metadata.

So in general, prefer `stack_data.Source` over `executing.Source` to consistently use the same Source objects everywhere. In this specific case, it seemed better to pull out the exact objects already provided by stack_data and executing.