### PR TITLE
Ensure registered reporters are returned by `RuntimeMessageParser.add` decorator

### DIFF
--- a/friendly_traceback/message_parser.py
+++ b/friendly_traceback/message_parser.py
@@ -9,12 +9,14 @@ imported from this module instead of simply from ``friendly_traceback``.
 
 
 from importlib import import_module
-from typing import List, Type
+from typing import List, Type, TypeVar
 
 from . import debug_helper
 from .ft_gettext import internal_error, no_information, unknown_case
 from .tb_data import TracebackData  # for type checking only
 from .typing_info import _E, CauseInfo, Parser
+
+_P = TypeVar("_P", bound=Parser)
 
 INCLUDED_PARSERS = {
     AttributeError: "attribute_error",
@@ -42,15 +44,16 @@ class RuntimeMessageParser:
         self.core_parsers: List[Parser] = []
         self.custom_parsers: List[Parser] = []
 
-    def _add(self, func: Parser) -> None:
+    def _add(self, func: _P) -> _P:
         """This method is meant to be used only within friendly-traceback.
         It is used as a decorator to add a message parser to a list that is
         automatically updated.
         """
         self.parsers.append(func)
         self.core_parsers.append(func)
+        return func
 
-    def add(self, func: Parser) -> None:
+    def add(self, func: _P) -> _P:
         """This method is meant to be used by projects that extend
         friendly-traceback. It is used as a decorator to add a message parser
         to a list that is automatically updated::
@@ -61,6 +64,7 @@ class RuntimeMessageParser:
         """
         self.custom_parsers.append(func)
         self.parsers = self.custom_parsers + self.core_parsers
+        return func
 
 
 def get_parser(exception_type: Type[_E]) -> RuntimeMessageParser:

--- a/friendly_traceback/typing_info.py
+++ b/friendly_traceback/typing_info.py
@@ -2,7 +2,6 @@
 
 import os
 import sys
-from types import FrameType
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Tuple, TypeVar, Union
 
 if TYPE_CHECKING:
@@ -101,11 +100,10 @@ else:
     SimilarNamesInfo = Dict[str, List[str]]
 
 
-Explain = Callable[[_E, FrameType, "TracebackData"], CauseInfo]
 GenericExplain = Callable[[], str]
 Parser = Union[
-    Callable[[str, FrameType, "TracebackData"], CauseInfo],
-    Callable[[_E, FrameType, "TracebackData"], CauseInfo],
+    Callable[[str, "TracebackData"], CauseInfo],
+    Callable[[_E, "TracebackData"], CauseInfo],
 ]
 Translator = Callable[[str], str]
 Writer = Callable[[str], None]


### PR DESCRIPTION
As mentioned in #165. @aroberge I have also amended the type hint for the `Parser` as the frame can be easily accessed from `TracebackData`, also removed the unused `Explain` type.