### PR TITLE
don't fail when collecting objects info on unparseable code line

### DIFF
--- a/friendly_traceback/info_variables.py
+++ b/friendly_traceback/info_variables.py
@@ -145,8 +145,13 @@ def get_all_objects(line: str, frame: types.FrameType) -> ObjectsInfo:
                         objects["name, type"].append((name, obj_type))
 
     line = line.strip()
-    if line.startswith(("def", "if", "while", "class", "for")) and line.endswith(":"):
+    if line.startswith(
+        ("def ", "if ", "while ", "class ", "for ", "with ")
+    ) and line.endswith(":"):
         line += " pass"
+
+    atok = None
+
     try:
         atok = ASTTokens(line.strip(), parse=True)
     except SyntaxError as e:


### PR DESCRIPTION
@aroberge another small PR that fixes `UnboundLocalError` occuring on unparseable lines, reproducible e.g. via
```python
>>> import inspect
>>> from friendly_traceback.info_variables import get_all_objects
>>> get_all_objects('x =', inspect.currentframe())
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/oleg.hoefling/projects/private/friendly-traceback/friendly_traceback/info_variables.py", line 163, in get_all_objects
    if atok is not None:
UnboundLocalError: local variable 'atok' referenced before assignment
```