### PR TITLE
fix: allow safe_repr to handle errors on attribute access

### DIFF
--- a/friendly_traceback/info_variables.py
+++ b/friendly_traceback/info_variables.py
@@ -448,12 +448,12 @@ def simplify_bound_method(name: str, splitlines: bool = False) -> str:
 
 
 def safe_repr(obj):
-    if hasattr(obj, "true_repr"):  # sourcery: skip
+    try:
         # guard against the case where obj == Friendly; #106
         obj_repr = str(obj.true_repr())
         # wrapped in str() for added security in case someone
         # else uses an attribute called true_repr
-    else:
+    except Exception:
         try:
             obj_repr = repr(obj)
         except Exception:  # issue #161: repr not returning a string

--- a/tests/unit/test_info_variables.py
+++ b/tests/unit/test_info_variables.py
@@ -119,5 +119,15 @@ def test_get_dotted_name_from_frame():
     frame = inspect.currentframe()
     assert ft.info_variables.get_object_from_name('itertools.count', frame) != None
 
+
+def test_safe_repr_can_handle_errors_on_attribute_access():
+
+    class Proxy:
+        def __getattr__(self, name):
+            raise NotImplementedError
+
+    assert ft.info_variables.safe_repr(Proxy())
+
+
 if __name__ == "__main__":
     test_get_variables_in_frame_by_scope()


### PR DESCRIPTION
@aroberge this is a fix for a subtle bug where `friendly_traceback.info_variables.safe_repr` fails to represent an object that raises error on attribute access. Originally discovered when testing a bug in `drf_spectacular`. Small script to reproduce:
```py
from drf_spectacular.drainage import GeneratorStats

stats = GeneratorStats()
hasattr(stats, 'spam')
```
Steps:
```sh
$ pip install drf-spectacular==0.22.1
$ django-admin startproject spam
$ cd spam
$ DJANGO_SETTINGS_MODULE='spam.settings' python -m friendly run.py 
Exception raised by friendly-traceback. Please report this case.
```
This is because `GeneratorStats` is caught in an infinite recursion when trying to access a non-existing attribute, and this is exactly what `safe_repr` does internally. The fix avoid this, so the `RecursionError` is displayed correctly now:
```sh
$ DJANGO_SETTINGS_MODULE='spam.settings' python -m friendly run.py 

╭──────────────────────────────────────────────────────────────────────────────────────── Traceback ─────────────────────────────────────────────────────────────────────────────────────────╮
│ Traceback (most recent call last):                                                                                                                                                         │
│   File "HOME:/projects/private/friendly-traceback/spam/run.py", line 4, in <module>                                                                                                        │
│     hasattr(stats, 'spam')                                                                                                                                                                 │
│        ... More lines not shown. ...                                                                                                                                                       │
│   File "LOCAL:/drf_spectacular/drainage.py", line 25, in __getattr__                                                                                                                       │
│     return getattr(self, name)                                                                                                                                                             │
│   File "LOCAL:/drf_spectacular/drainage.py", line 25, in __getattr__                                                                                                                       │
│     return getattr(self, name)                                                                                                                                                             │
│ RecursionError: maximum recursion depth exceeded while calling a Python object                                                                                                             │
│                                                                                                                                                                                            │
│ A RecursionError is raised when a function calls itself, directly or indirectly, too many times. It almost always indicates that you made an error in your code and that your program      │
│ would never stop.                                                                                                                                                                          │
│                                                                                                                                                                                            │
│ Execution stopped on line 4 of file 'HOME:/projects/private/friendly-traceback/spam/run.py'.                                                                                               │
│                                                                                                                                                                                            │
│        1| from drf_spectacular.drainage import GeneratorStats                                                                                                                              │
│        2|                                                                                                                                                                                  │
│        3| stats = GeneratorStats()                                                                                                                                                         │
│      > 4| hasattr(stats, 'spam')                                                                                                                                                           │
│                                                                                                                                                                                            │
│     stats:  <drf_spectacular.drainage.GeneratorStats object>                                                                                                                               │
│     hasattr:  <builtin function hasattr>                                                                                                                                                   │
│                                                                                                                                                                                            │
│ Exception raised on line 25 of file 'LOCAL:/drf_spectacular/drainage.py'.                                                                                                                  │
│                                                                                                                                                                                            │
│        22| if not self.__dict__:                                                                                                                                                           │
│        23|     from drf_spectacular.settings import spectacular_settings                                                                                                                   │
│        24|     self.silent = spectacular_settings.DISABLE_ERRORS_AND_WARNINGS                                                                                                              │
│      > 25| return getattr(self, name)                                                                                                                                                      │
│                                                                                                                                                                                            │
│     name:  'spam'                                                                                                                                                                          │
│     self:  <drf_spectacular.drainage.GeneratorStats object>                                                                                                                                │
│     getattr:  <builtin function getattr>                                                                                                                                                   │
╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```
Also added a simple unit test to reproduce this issue.