### PR TITLE
typing: expose error type from tracebackdata

### DIFF
--- a/friendly_traceback/tb_data.py
+++ b/friendly_traceback/tb_data.py
@@ -5,7 +5,7 @@ import sys
 import traceback
 import types
 from itertools import dropwhile
-from typing import List, Optional, Tuple, Type
+from typing import Generic, List, Optional, Tuple, Type
 
 from stack_data import BlankLines, Options
 
@@ -50,7 +50,7 @@ def retrieve_message(etype: Type[_E], value: _E, tb: types.TracebackType) -> str
     return full_message.split(":", 1)[1].strip()
 
 
-class TracebackData:
+class TracebackData(Generic[_E]):
     """Raw traceback info obtained from Python.
 
     Instances of this class are intended to include all the relevant
@@ -78,9 +78,9 @@ class TracebackData:
         self.bad_line = "\n"
         self.original_bad_line = "\n"
         self.filename = ""
-        self.exception_frame = None
-        self.exception_instance = None
-        self.program_stopped_frame = None
+        self.exception_frame: Optional[types.FrameType] = None
+        self.exception_instance: Optional[_E] = None
+        self.program_stopped_frame: Optional[types.FrameType] = None
         self.program_stopped_bad_line = "\n"
         self.get_source_info()
 


### PR DESCRIPTION
@aroberge this allows fine-grained hints in custom error reporters, e.g. for
```py
from friendly_traceback.core import TracebackData
from friendly_traceback.message_parser import get_parser
from friendly_traceback.typing_info import CauseInfo


class MyError(Exception): ...


parser = get_parser(MyError)


@parser.add
def my_report(message: str, tb_data: TracebackData[MyError]) -> CauseInfo:
    reveal_type(tb_data)
    reveal_type(tb_data.exception_type)
    reveal_type(tb_data.exception_name)
    reveal_type(tb_data.value)
    reveal_type(tb_data.exception_frame)
    return {}
```
`mypy` will report
```
foo.py:15: note: Revealed type is "friendly_traceback.tb_data.TracebackData[foo.MyError]"
foo.py:16: note: Revealed type is "Type[foo.MyError]"
foo.py:17: note: Revealed type is "builtins.str"
foo.py:18: note: Revealed type is "foo.MyError"
foo.py:19: note: Revealed type is "Union[types.FrameType, None]"
```