### PR TITLE
remove now unused dependecy on "six"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@ asttokens >= 2.0.4
 executing >= 1.1.0
 pure_eval >= 0.2.1
 stack_data >= 0.6.2
-six >= 1.16

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,6 @@ install_requires =
     executing >= 1.1.0
     pure_eval >= 0.2.1
     stack_data >= 0.6.2
-    six >= 1.16
 
 [options.packages.find]
 exclude =


### PR DESCRIPTION
Hi,

Your package enterred Debian today.

I noticed it was requiring `six` but not actualy using it.

Greetings

https://wiki.debian.org/Python3-six-removal

## Summary by Sourcery

Chores:
- Remove 'six' package from requirements and setup configuration as it is no longer used